### PR TITLE
Some fixes and Exploits integration

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: Quests
 main: io.github.feydk.Quests.QuestsPlugin
 description: Quests will create a quest for you every day. Completing a quest will earn you a reward.
 database: true
-depend: [ Vault, Fe ]
+depend: [ Vault, Fe, Exploits ]
 version: 1.0
 commands:
   quest:

--- a/src/io/github/feydk/Quests/CraftQuest.java
+++ b/src/io/github/feydk/Quests/CraftQuest.java
@@ -34,13 +34,7 @@ public class CraftQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = (Player)event.getWhoClicked();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-				
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/DamageQuest.java
+++ b/src/io/github/feydk/Quests/DamageQuest.java
@@ -11,6 +11,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.permissions.Permissible;
+import org.bukkit.projectiles.ProjectileSource;
 
 // Take damage quests can be any of the following:
 // 1. Take a certain amount of damage (hearts), no matter how.
@@ -71,7 +72,8 @@ public class DamageQuest extends BaseQuest implements Listener
 					
 					if(damager instanceof Arrow)
 					{
-						damager = ((Arrow)damager).getShooter();
+						ProjectileSource shooter = ((Arrow)damager).getShooter();
+						if (shooter instanceof Entity) damager = (Entity)shooter;
 					}
 					
 					if(config.Entities.contains(damager.getType()))

--- a/src/io/github/feydk/Quests/DamageQuest.java
+++ b/src/io/github/feydk/Quests/DamageQuest.java
@@ -43,13 +43,7 @@ public class DamageQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = (Player)event.getEntity();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/EatQuest.java
+++ b/src/io/github/feydk/Quests/EatQuest.java
@@ -33,13 +33,7 @@ public class EatQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = event.getPlayer();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;
@@ -73,13 +67,7 @@ public class EatQuest extends BaseQuest implements Listener
 		if(event.getClickedBlock().getType() == Material.CAKE_BLOCK && event.getAction() == Action.RIGHT_CLICK_BLOCK)
 		{
 			Player p = event.getPlayer();
-			QuestPlayer player = plugin.players.get(p.getUniqueId());
-			
-			if(player.getCurrentQuest() == null)
-			{
-				plugin.handleNullQuest(p);
-				return;
-			}
+			QuestPlayer player = plugin.getQuestPlayer(p);
 			
 			if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 				return;

--- a/src/io/github/feydk/Quests/EnchantQuest.java
+++ b/src/io/github/feydk/Quests/EnchantQuest.java
@@ -44,13 +44,7 @@ public class EnchantQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = (Player)event.getEnchanter();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/FishQuest.java
+++ b/src/io/github/feydk/Quests/FishQuest.java
@@ -32,13 +32,7 @@ public class FishQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = event.getPlayer();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/GrowQuest.java
+++ b/src/io/github/feydk/Quests/GrowQuest.java
@@ -46,13 +46,7 @@ public class GrowQuest extends BaseQuest implements Listener
 			return;
 		
 		final Player p = event.getPlayer();
-		final QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		final QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/KillQuest.java
+++ b/src/io/github/feydk/Quests/KillQuest.java
@@ -42,13 +42,7 @@ public class KillQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = event.getEntity().getKiller();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/MineQuest.java
+++ b/src/io/github/feydk/Quests/MineQuest.java
@@ -5,6 +5,7 @@ import io.github.feydk.Quests.Config.MineConfig;
 import java.util.Collection;
 import java.util.Map.Entry;
 
+import com.winthier.exploits.bukkit.BukkitExploits;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -48,13 +49,9 @@ public class MineQuest extends BaseQuest implements Listener
 		{
 			if(!checkGenericRequirements(player.getCurrentQuest().getQuest().getConfig(), p))
 				return;
-			
-			// Ignore if the tool used to mine the block has silk touch on it.
-			for(Entry<Enchantment, Integer> ench : p.getItemInHand().getEnchantments().entrySet())
-			{	
-				if(ench.getKey().getName().equals("SILK_TOUCH"))
-					return;
-			}
+
+			// Ignore if the block was placed by a player.
+			if (BukkitExploits.getInstance().isPlayerPlaced(event.getBlock())) return;
 			
 			MineConfig config = (MineConfig)player.getCurrentQuest().getQuest().getConfig();
 			

--- a/src/io/github/feydk/Quests/MineQuest.java
+++ b/src/io/github/feydk/Quests/MineQuest.java
@@ -39,13 +39,7 @@ public class MineQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = event.getPlayer();		
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/QuestScheduler.java
+++ b/src/io/github/feydk/Quests/QuestScheduler.java
@@ -3,7 +3,6 @@ package io.github.feydk.Quests;
 import java.util.List;
 
 import org.bukkit.ChatColor;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -37,8 +36,6 @@ public class QuestScheduler extends BukkitRunnable
 		{
 			for(QuestPlayer p : players)
 			{
-				OfflinePlayer entity = plugin.getServer().getOfflinePlayer(p.getModel().UUID);
-				
 				// If the quest status is Accepted, it means the player didn't complete it in time.
 				if(p.getCurrentQuest().getPlayerQuestModel().Status == QuestStatus.Accepted)
 				{
@@ -54,7 +51,8 @@ public class QuestScheduler extends BukkitRunnable
 					p.getCurrentQuest().setProcessed();
 					
 					// And if player is online, send him a message, create a new quest and send him a notification about that new quest.
-					if(entity.isOnline())
+					Player entity = plugin.getServer().getPlayer(p.getModel().UUID);
+					if(entity != null)
 					{
 						String msg = " " + ChatColor.AQUA + "Aaawww! You didn't manage to complete your quest in time.";
 						
@@ -64,14 +62,14 @@ public class QuestScheduler extends BukkitRunnable
 						msg += "\n A new quest will be created for you shortly..";
 						
 						if(!PluginConfig.SOFT_LAUNCH)
-							((Player)entity).sendMessage(msg);
+							entity.sendMessage(msg);
 						
 						p.giveRandomQuest();
 						
-						plugin.players.replace(p.getModel().UUID, p);
+						plugin.removeQuestPlayer(p.getModel().UUID);
 						
 						if(!PluginConfig.SOFT_LAUNCH)
-							plugin.notifyPlayerOfQuest((Player)entity, p.getCurrentQuest().getPlayerQuestModel().Status, 50);
+							plugin.notifyPlayerOfQuest(entity, p.getCurrentQuest().getPlayerQuestModel().Status, 50);
 					}
 				}
 				// If the quest has any other status..
@@ -81,14 +79,15 @@ public class QuestScheduler extends BukkitRunnable
 					p.getCurrentQuest().setProcessed();
 					
 					// And if player is online, create a new quest and send him a notification about it.
-					if(entity.isOnline())
+					Player entity = plugin.getServer().getPlayer(p.getModel().UUID);
+					if(entity != null)
 					{
 						p.giveRandomQuest();
 						
-						plugin.players.replace(p.getModel().UUID, p);
+						plugin.removeQuestPlayer(p.getModel().UUID);
 						
 						if(!PluginConfig.SOFT_LAUNCH)
-							plugin.notifyPlayerOfQuest((Player)entity, p.getCurrentQuest().getPlayerQuestModel().Status, 50);
+							plugin.notifyPlayerOfQuest(entity, p.getCurrentQuest().getPlayerQuestModel().Status, 50);
 					}
 				}
 			}

--- a/src/io/github/feydk/Quests/QuestsPlugin.java
+++ b/src/io/github/feydk/Quests/QuestsPlugin.java
@@ -599,6 +599,11 @@ public class QuestsPlugin extends JavaPlugin implements Listener
 			// Give player a random quest.
 			player.giveRandomQuest();
 		}
+                else if(!name.equals(player.getModel().Name))
+                {
+                    player.getModel().Name = name;
+                    player.getModel().update();
+                }
 
 		questPlayers.put(uuid, player);
 		

--- a/src/io/github/feydk/Quests/SmeltQuest.java
+++ b/src/io/github/feydk/Quests/SmeltQuest.java
@@ -33,13 +33,7 @@ public class SmeltQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = (Player)event.getPlayer();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;
@@ -83,13 +77,7 @@ public class SmeltQuest extends BaseQuest implements Listener
 			return;
 		
 		Player p = (Player)event.getWhoClicked();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/TameQuest.java
+++ b/src/io/github/feydk/Quests/TameQuest.java
@@ -35,13 +35,7 @@ public class TameQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = (Player)event.getOwner();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/ThrowEggQuest.java
+++ b/src/io/github/feydk/Quests/ThrowEggQuest.java
@@ -34,13 +34,7 @@ public class ThrowEggQuest extends BaseQuest implements Listener
 		}
 		
 		Player p = (Player)event.getPlayer();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-				
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;

--- a/src/io/github/feydk/Quests/TradeQuest.java
+++ b/src/io/github/feydk/Quests/TradeQuest.java
@@ -31,13 +31,7 @@ public class TradeQuest extends BaseQuest implements Listener
 			return;
 		
 		Player p = (Player)event.getWhoClicked();
-		QuestPlayer player = plugin.players.get(p.getUniqueId());
-		
-		if(player.getCurrentQuest() == null)
-		{
-			plugin.handleNullQuest(p);
-			return;
-		}
+		QuestPlayer player = plugin.getQuestPlayer(p);
 		
 		if(player.getCurrentQuest().getPlayerQuestModel().Status != QuestStatus.Accepted)
 			return;


### PR DESCRIPTION
PlayerQuest was not created when a new player joined, since they lack the quests permission, but once they rank up and can use quests, an NPE is thrown. Therefore, I decided to refactor QuestsPlugin to use getQuestPlayer(), which lazily creates player data on demand.
Projectile.getShooter() returns DamageSource instead of Entity, so I updated DamageQuest accordingly.
I replaced the silk touch check in MineQuest with an check in the Exploits plugin, like we discussed.